### PR TITLE
update ami filter

### DIFF
--- a/terraform-aws/aws.tf
+++ b/terraform-aws/aws.tf
@@ -15,7 +15,7 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-*-amd64-server-*"]
   }
 
   filter {


### PR DESCRIPTION
There were problems during the apply of the userdata.  

Some of the installs do not support the `bionic` release that was specified the in filter for data.aws_ami.

I updated the filter to choose the lastest version through the filter:

```
values = ["ubuntu/images/hvm-ssd/ubuntu-*-amd64-server-*"]
```